### PR TITLE
cmake 3.0 is enough

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.0)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 	set(CMAKE_BUILD_TYPE "RelWithDebInfo")
@@ -34,7 +34,7 @@ set(LIBINCLUDE
   iir/PoleFilter.h
   iir/RBJ.h
   iir/State.h
-  iir/Types.h) 
+  iir/Types.h)
 
 add_library(iir
   SHARED

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.0)
 
 add_executable (iirdemo iirdemo.cpp)
 target_link_libraries(iirdemo iir_static)

--- a/iir/Biquad.cpp
+++ b/iir/Biquad.cpp
@@ -7,7 +7,7 @@
  * https://github.com/berndporr/iir1
  *
  * See Documentation.cpp for contact information, notes, and bibliography.
- * 
+ *
  * -----------------------------------------------------------------
  *
  * License: MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -36,6 +36,7 @@
 #include "Common.h"
 #include "MathSupplement.h"
 #include "Biquad.h"
+#include <stdexcept>
 
 namespace Iir {
 
@@ -142,14 +143,14 @@ namespace Iir {
 	{
 		if (pole.imag() != 0) throw std::invalid_argument("Imaginary part of pole is non-zero.");
 		if (zero.imag() != 0) throw std::invalid_argument("Imaginary part of zero is non-zero.");
-	
+
 		const double a0 = 1;
 		const double a1 = -pole.real();
 		const double a2 = 0;
 		const double b0 = -zero.real();
 		const double b1 = 1;
 		const double b2 = 0;
-	
+
 		setCoefficients (a0, a1, a2, b0, b1, b2);
 	}
 

--- a/iir/Cascade.h
+++ b/iir/Cascade.h
@@ -7,7 +7,7 @@
  * https://github.com/berndporr/iir1
  *
  * See Documentation.cpp for contact information, notes, and bibliography.
- * 
+ *
  * -----------------------------------------------------------------
  *
  * License: MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -40,6 +40,7 @@
 #include "Biquad.h"
 #include "Layout.h"
 #include "MathSupplement.h"
+#include <stdexcept>
 
 namespace Iir {
 

--- a/iir/Layout.h
+++ b/iir/Layout.h
@@ -7,7 +7,7 @@
  * https://github.com/berndporr/iir1
  *
  * See Documentation.cpp for contact information, notes, and bibliography.
- * 
+ *
  * -----------------------------------------------------------------
  *
  * License: MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -38,6 +38,7 @@
 
 #include "Common.h"
 #include "MathSupplement.h"
+#include <stdexcept>
 
 /**
  * Describes a filter as a collection of poles and zeros along with
@@ -48,12 +49,12 @@ namespace Iir {
 
 	static const char errPoleisNaN[] = "Pole to add is NaN.";
 	static const char errZeroisNaN[] = "Zero to add is NaN.";
-	
+
 	static const char errCantAdd2ndOrder[] = "Can't add 2nd order after a 1st order filter.";
 
 	static const char errPolesNotComplexConj[] = "Poles not complex conjugate.";
 	static const char errZerosNotComplexConj[] = "Zeros not complex conjugate.";
-	
+
 	static const char pairIndexOutOfBounds[] = "Pair index out of bounds.";
 
 /**

--- a/iir/Types.h
+++ b/iir/Types.h
@@ -7,7 +7,7 @@
  * https://github.com/berndporr/iir1
  *
  * See Documentation.cpp for contact information, notes, and bibliography.
- * 
+ *
  * -----------------------------------------------------------------
  *
  * License: MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -38,6 +38,7 @@
 
 #include "Common.h"
 #include "MathSupplement.h"
+#include <stdexcept>
 
 namespace Iir {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.0)
 enable_testing()
 include_directories(
   ..


### PR DESCRIPTION
To allow building on older systems reduce the minimum required cmake version. It doesn't appear any advanced new cmake features are used anyway.