### PR TITLE
Add Support for CMake FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,10 @@ set(LIBINCLUDE
   iir/State.h
   iir/Types.h)
 
-add_library(iir
-  SHARED
-  ${LIBSRC}
-  )
+add_library(iir SHARED ${LIBSRC})
+add_library(iir::iir ALIAS iir)
 
-target_include_directories(iir 
+target_include_directories(iir
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>      # for Iir.h
   PRIVATE
@@ -80,12 +78,10 @@ install(TARGETS iir EXPORT iir-targets
 
 configure_file(iir.pc.in iir.pc @ONLY)
 
-add_library(iir_static
-  STATIC
-  ${LIBSRC}
-  )
+add_library(iir_static STATIC ${LIBSRC})
+add_library(iir::iir_static ALIAS iir_static)
 
-  target_include_directories(iir_static
+target_include_directories(iir_static
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>      # for Iir.h
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,12 @@ add_library(iir
   ${LIBSRC}
   )
 
-target_include_directories(iir PRIVATE iir)
+target_include_directories(iir 
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>      # for Iir.h
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/iir>  # everything else
+)
 
 set_target_properties(iir PROPERTIES
   SOVERSION 1
@@ -80,7 +85,12 @@ add_library(iir_static
   ${LIBSRC}
   )
 
-target_include_directories(iir_static PRIVATE iir)
+  target_include_directories(iir_static
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>      # for Iir.h
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/iir>  # everything else
+)
 
 set_target_properties(iir_static PROPERTIES
   VERSION ${PROJECT_VERSION}


### PR DESCRIPTION
This PR makes a small modification to `CMakeLists.txt` to enable the library to be used with the `FetchContent` feature, obviating the need to build and install separately:

```cmake
include(FetchContent) 
FetchContent_Declare(iir GIT_REPOSITORY https://github.com/berndporr/iir1) 
FetchContent_MakeAvailable(iir)

add_executable(filter_toy "filter_toy.cpp")
target_link_libraries(filter_toy iir::iir_static)
```

