### PR TITLE
Fix mistake in definition

### DIFF
--- a/test/chebyshev1.cpp
+++ b/test/chebyshev1.cpp
@@ -9,7 +9,7 @@
 int main(int, char**)
 {
 	const int order = 3;
-	Iir::ChebyshevI::HighPass<order> f;
+	Iir::ChebyshevI::LowPass<order> f;
 	const float samplingrate = 1000; // Hz
 	const float cutoff_frequency = 5; // Hz
 	f.setup(samplingrate, cutoff_frequency, 1);


### PR DESCRIPTION
In the unit test, this block is lowpass test however the definition of the filter is 'HighPass'. 