### PR TITLE
Cleanup minor GCC and MSVC warnings

### DIFF
--- a/iir/Biquad.h
+++ b/iir/Biquad.h
@@ -155,12 +155,12 @@ namespace Iir {
 		void applyScale (double scale);
 
 	public:
-		double m_a0 = 1;
-		double m_a1 = 0;
-		double m_a2 = 0;
-		double m_b1 = 0;
-		double m_b2 = 0;
-		double m_b0 = 1;
+		double m_a0 = 1.0;
+		double m_a1 = 0.0;
+		double m_a2 = 0.0;
+		double m_b1 = 0.0;
+		double m_b2 = 0.0;
+		double m_b0 = 1.0;
 	};
 
 //------------------------------------------------------------------------------
@@ -176,7 +176,7 @@ namespace Iir {
 
 		explicit BiquadPoleState (const Biquad& s);
 
-		double gain = 1;
+		double gain = 1.0;
 	};
 
 }

--- a/iir/Butterworth.h
+++ b/iir/Butterworth.h
@@ -62,7 +62,7 @@ public:
 	void design (const int numPoles);
 
 private:
-	int m_numPoles;
+	int m_numPoles = 0;
 };
 
 //------------------------------------------------------------------------------
@@ -78,8 +78,8 @@ public:
 	void design (int numPoles, double gainDb);
 
 private:
-	int m_numPoles;
-	double m_gainDb;
+	int m_numPoles = 0;
+	double m_gainDb = 0.0;
 };
 
 //------------------------------------------------------------------------------

--- a/iir/Cascade.h
+++ b/iir/Cascade.h
@@ -66,8 +66,8 @@ namespace Iir {
                 {
                 }
 
-                const int maxStages;
-                Biquad* const stageArray;
+                const int maxStages = 0;
+                Biquad* const stageArray = nullptr;
         };
 
         /**
@@ -109,9 +109,9 @@ namespace Iir {
         void setLayout (const LayoutBase& proto);
 
         private:
-        int m_numStages;
-        int m_maxStages;
-        Biquad* m_stageArray;
+        int m_numStages = 0;
+        int m_maxStages = 0;
+        Biquad* m_stageArray = nullptr;
         };
 
 
@@ -177,8 +177,8 @@ namespace Iir {
         }
         
         private:
-        Biquad m_stages[MaxStages];
-        StateType m_states[MaxStages];
+        Biquad m_stages[MaxStages] = {};
+        StateType m_states[MaxStages] = {};
         };
         
 }

--- a/iir/ChebyshevI.h
+++ b/iir/ChebyshevI.h
@@ -61,8 +61,8 @@ public:
 		     double rippleDb);
 
 private:
-	int m_numPoles;
-	double m_rippleDb;
+	int m_numPoles = 0;
+	double m_rippleDb = 0.0;
 };
 
 /**
@@ -78,9 +78,9 @@ public:
 		     double rippleDb);
 
 private:
-	int m_numPoles;
-	double m_rippleDb;
-	double m_gainDb;
+	int m_numPoles = 0;
+	double m_rippleDb = 0.0;
+	double m_gainDb = 0.0;
 };
 
 //------------------------------------------------------------------------------

--- a/iir/ChebyshevII.h
+++ b/iir/ChebyshevII.h
@@ -64,8 +64,8 @@ public:
 		     double stopBandDb);
 
 private:
-	int m_numPoles;
-	double m_stopBandDb;
+	int m_numPoles = 0;
+	double m_stopBandDb = 0.0;
 };
 
 
@@ -82,9 +82,9 @@ public:
 		     double stopBandDb);
 
 private:
-	int m_numPoles;
-	double m_stopBandDb;
-	double m_gainDb;
+	int m_numPoles = 0;
+	double m_stopBandDb = 0.0;
+	double m_gainDb = 0.0;
 };
 
 //------------------------------------------------------------------------------

--- a/iir/Common.h
+++ b/iir/Common.h
@@ -46,10 +46,12 @@
 
 // This exports the classes/structures to the windows DLL
 #ifdef _WIN32
-#define DllExport   __declspec( dllexport )
-#define _CRT_SECURE_NO_WARNINGS
+#  define DllExport   __declspec( dllexport )
+#  ifndef _CRT_SECURE_NO_WARNINGS
+#    define _CRT_SECURE_NO_WARNINGS
+#  endif
 #else
-#define DllExport
+#  define DllExport
 #endif
 
 #include <stdlib.h>

--- a/iir/Custom.h
+++ b/iir/Custom.h
@@ -93,7 +93,7 @@ struct DllExport SOSCascade : CascadeStages<NSOS,StateType>
 	 * Default constructor which creates a unity gain filter of NSOS biquads.
 	 * Set the filter coefficients later with the setup() method.
 	 **/
-	SOSCascade() {};
+	SOSCascade() {}
 	/**
          * Python scipy.signal-friendly setting of coefficients.
 	 * Initialises the coefficients of the whole chain of
@@ -106,7 +106,7 @@ struct DllExport SOSCascade : CascadeStages<NSOS,StateType>
 	 **/
 	SOSCascade(const double (&sosCoefficients)[NSOS][6]) {
 		CascadeStages<NSOS,StateType>::setup(sosCoefficients);
-	};
+	}
 	/**
          * Python scipy.signal-friendly setting of coefficients.
 	 * Sets the coefficients of the whole chain of

--- a/iir/Layout.h
+++ b/iir/Layout.h
@@ -65,6 +65,7 @@ namespace Iir {
 		LayoutBase ()
 			: m_numPoles (0)
 			, m_maxPoles (0)
+			, m_pair (nullptr)
 		{
 		}
 
@@ -165,9 +166,9 @@ namespace Iir {
 		}
 
 	private:
-		int m_numPoles;
-		int m_maxPoles;
-		PoleZeroPair* m_pair;
+		int m_numPoles = 0;
+		int m_maxPoles = 0;
+		PoleZeroPair* m_pair = nullptr;
 		double m_normalW = 0;
 		double m_normalGain = 1;
 	};
@@ -187,7 +188,7 @@ namespace Iir {
 		}
 
 	private:
-		PoleZeroPair m_pairs[(MaxPoles+1)/2];
+		PoleZeroPair m_pairs[(MaxPoles+1)/2] = {};
 	};
 
 }

--- a/iir/PoleFilter.h
+++ b/iir/PoleFilter.h
@@ -77,7 +77,7 @@ public:
   }
 
 protected:
-  LayoutBase m_digitalProto;
+  LayoutBase m_digitalProto = {};
 };
 
 
@@ -97,7 +97,7 @@ protected:
   }
 
 protected:
-  AnalogPrototype m_analogProto;
+  AnalogPrototype m_analogProto = {};
 };
 
 //------------------------------------------------------------------------------
@@ -121,8 +121,8 @@ template <class BaseClass,
   }
 
 private:
-  Layout <MaxAnalogPoles> m_analogStorage;
-  Layout <MaxDigitalPoles> m_digitalStorage;
+  Layout <MaxAnalogPoles> m_analogStorage = {};
+  Layout <MaxDigitalPoles> m_digitalStorage = {};
 };
 
 //------------------------------------------------------------------------------
@@ -151,7 +151,7 @@ public:
 private:
   complex_t transform (complex_t c);
 
-  double f;
+  double f = 0.0;
 };
 
 //------------------------------------------------------------------------------
@@ -169,7 +169,7 @@ public:
 private:
   complex_t transform (complex_t c);
 
-  double f;
+  double f = 0.0;
 };
 
 //------------------------------------------------------------------------------
@@ -189,14 +189,14 @@ public:
 private:
   ComplexPair transform (complex_t c);
 
-  double wc;
-  double wc2;
-  double a;
-  double b;
-  double a2;
-  double b2;
-  double ab;
-  double ab_2;
+  double wc = 0.0;
+  double wc2 = 0.0;
+  double a = 0.0;
+  double b = 0.0;
+  double a2 = 0.0;
+  double b2 = 0.0;
+  double ab = 0.0;
+  double ab_2 = 0.0;
 };
 
 //------------------------------------------------------------------------------
@@ -215,12 +215,12 @@ public:
 private:
   ComplexPair transform (complex_t c);
 
-  double wc;
-  double wc2;
-  double a;
-  double b;
-  double a2;
-  double b2;
+  double wc = 0.0;
+  double wc2 = 0.0;
+  double a = 0.0;
+  double b = 0.0;
+  double a2 = 0.0;
+  double b2 = 0.0;
 };
 
 }

--- a/iir/State.h
+++ b/iir/State.h
@@ -82,10 +82,10 @@ namespace Iir {
 	}
 	
 	protected:
-	double m_x2 = 0; // x[n-2]
-	double m_y2 = 0; // y[n-2]
-	double m_x1 = 0; // x[n-1]
-	double m_y1 = 0; // y[n-1]
+	double m_x2 = 0.0; // x[n-2]
+	double m_y2 = 0.0; // y[n-2]
+	double m_x1 = 0.0; // x[n-1]
+	double m_y1 = 0.0; // y[n-1]
 	};
 
 //------------------------------------------------------------------------------
@@ -109,8 +109,8 @@ namespace Iir {
 	
 	void reset ()
 	{
-		m_v1 = 0;
-		m_v2 = 0;
+		m_v1 = 0.0;
+		m_v2 = 0.0;
 	}
 	
 	inline double filter(const double in,
@@ -126,8 +126,8 @@ namespace Iir {
 	}
 	
 	private:
-	double m_v1 = 0; // v[-1]
-	double m_v2 = 0; // v[-2]
+	double m_v1 = 0.0; // v[-1]
+	double m_v2 = 0.0; // v[-2]
 	};
 
 
@@ -136,17 +136,13 @@ namespace Iir {
 	class DllExport TransposedDirectFormII
 	{
 	public:
-	TransposedDirectFormII ()
-	{
-		reset ();
-	}
-	
+	TransposedDirectFormII() = default;
 	void reset ()
 	{
-		m_s1 = 0;
-		m_s1_1 = 0;
-		m_s2 = 0;
-		m_s2_1 = 0;
+		m_s1 = 0.0;
+		m_s1_1 = 0.0;
+		m_s2 = 0.0;
+		m_s2_1 = 0.0;
 	}
 	
 	inline double filter(const double in,
@@ -162,10 +158,10 @@ namespace Iir {
 	}
 	
 	private:
-	double m_s1 = 0;
-	double m_s1_1 = 0;
-	double m_s2 = 0;
-	double m_s2_1 = 0;
+	double m_s1 = 0.0;
+	double m_s1_1 = 0.0;
+	double m_s2 = 0.0;
+	double m_s2_1 = 0.0;
 	};
 
 }

--- a/iir/Types.h
+++ b/iir/Types.h
@@ -98,10 +98,14 @@ namespace Iir {
  **/
 	struct DllExport PoleZeroPair
 	{
-		ComplexPair poles;
-		ComplexPair zeros;
+		ComplexPair poles = {};
+		ComplexPair zeros = {};
 
-		PoleZeroPair () { }
+		PoleZeroPair ()
+			: poles(0.0, 0.0)
+			, zeros(0.0, 0.0)
+		{
+		}
 
 		// single pole/zero
 		PoleZeroPair (const complex_t& p, const complex_t& z)


### PR DESCRIPTION
@berndporr , thanks for considering this PR.

I've confirmed that this cleans up all our warnings across all compilers:
 - GCC 7.x through 11.x
 - Clang 10.x through 14.x
 - VS 2019 and 2022

In the spirit of being explicit, I'm using the literal notation for the types:
 - `0` => literal integer
 - `0.0` => literal double
 - `0.0f` => literal float

For casual readers, things like the following become obvious that the variables are doubles:

``` c++
m_v1 = 0.0;
m_v2 = 0.0;
```

Also, with the default initializers in `TransposedDirectFormII`, the `reset()` call in its constructor is no longer needed. And instead of implementing a placeholder constructor, used the recommended C++11 notation instead:

``` C++
TransposedDirectFormII() = default;
```

(happy to remove that and go back to `reset()`, if desired).