### PR TITLE
Use a default constructor for SOSCascade

### DIFF
--- a/iir/Custom.h
+++ b/iir/Custom.h
@@ -93,7 +93,7 @@ struct DllExport SOSCascade : CascadeStages<NSOS,StateType>
 	 * Default constructor which creates a unity gain filter of NSOS biquads.
 	 * Set the filter coefficients later with the setup() method.
 	 **/
-	SOSCascade() {}
+	SOSCascade() = default;
 	/**
          * Python scipy.signal-friendly setting of coefficients.
 	 * Initialises the coefficients of the whole chain of


### PR DESCRIPTION
Appologies for the PR churn, @berndporr --  this should be the last of the `default;` constructors.

Here's what we've got:
```
iir/Biquad.h:   BiquadPoleState () = default;
iir/Custom.h:   SOSCascade() = default;
iir/State.h:    DirectFormI () = default;
iir/State.h:    DirectFormII () = default;
iir/State.h:    TransposedDirectFormII() = default;
iir/Types.h:    ComplexPair() = default;
iir/Types.h:    PoleZeroPair () = default;
```