### PR TITLE
make the pkg-config file work again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.1.0)
 
 project(iir VERSION 1.9.2 LANGUAGES CXX)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake_extras")
+
 set(CMAKE_CXX_STANDARD 11)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -71,7 +73,14 @@ install(TARGETS iir EXPORT iir-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   PRIVATE_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/iir)
 
+include(JoinPaths)
+
+join_paths(includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+join_paths(libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+
 configure_file(iir.pc.in iir.pc @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/iir.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 add_library(iir_static STATIC ${LIBSRC})
 add_library(iir::iir_static ALIAS iir_static)

--- a/cmake_extras/JoinPaths.cmake
+++ b/cmake_extras/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/iir.pc.in
+++ b/iir.pc.in
@@ -1,11 +1,10 @@
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
-Name: @IIR@
+Name: @PROJECT_NAME@
 Description: IIR filter library.
-Version: @PACKAGE_VERSION@
-URL: @PACKAGE_URL@
+Version: @PROJECT_VERSION@
+URL: https://www.berndporr.me.uk/iir/
 Libs: -L${libdir} -liir
-Cflags: -I${includedir}/iir -I${includedir}
+Cflags: -I${includedir}


### PR DESCRIPTION
In commit 45b0cbfe4c29c69bc06a967947e3b77c7e988038 the project was ported from autotools to cmake.
In commit 512b6cba5ec7537953d24dbe546c488d657c68a1 autotools support was dropped.

During the port, the iir.pc file was hooked up to cmake, but unlike autotools, cmake doesn't have many variables hooked up for this (and needs quite a bit of help to correctly define install paths, especially). None of that was handled, however... and also the cmake setup only configured the file, but did not install it.

Add this support back.

Due to https://github.com/jtojnar/cmake-snips/#concatenating-paths-when-building-pkg-config-filesa third-party function needs to be included in order to correctly define prefix/libdir/includedir in the pkg-config file.