### PR TITLE
Default-initialize `RBJbase`'s `state` member

### DIFF
--- a/iir/RBJ.h
+++ b/iir/RBJ.h
@@ -80,7 +80,7 @@ namespace RBJ {
 			return state;
 		}
 	private:
-		DirectFormI state;
+		DirectFormI state = {};
 	};
 
 	/**


### PR DESCRIPTION
The DllExport of RBJbase generates a default constructor, `Iir::RBJ::RBJbase::RBJbase()`, which leaves `RBJbase`'s `state` member uninitialized.

Reported by @FeralChild64 on Gentoo Linux, AMD64, GCC 11.3.0:

https://github.com/dosbox-staging/dosbox-staging/pull/1820#issuecomment-1197252870
```
iir1-1.9.3/iir/RBJ.h: In constructor 'constexpr
Iir::RBJ::RBJbase::RBJbase()':

iir1-1.9.3/iir/RBJ.h:66:26: warning:
   'Iir::RBJ::RBJbase::state' should be initialized in the
   member initialization list [-Weffc++] 66 | struct DllExport
   RBJbase : Biquad
```
