### PR TITLE
Modified root CMakeLists to include a toggle for building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,10 @@ cmake_policy(SET CMP0042 NEW) # enable MACOSX_RPATH by default
 option(INSTALL_STATIC "Build static library" ON)
 
 include(GNUInstallDirs)
-add_subdirectory(test)
+# If including this project in another project, use IIR1_BUILD_TESTING to enable local testing
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR IIR1_BUILD_TESTING) AND BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 add_subdirectory(demo)
 enable_testing ()
 


### PR DESCRIPTION
The project now uses the `BUILD_TESTING` option to build tests. 
In case this project is included within another one, and more control in test building is needed, the `IIR1_BUILD_TESTING` option has been added.