### PR TITLE
Properly export symbols in shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ target_include_directories(iir
 set_target_properties(iir PROPERTIES
   SOVERSION 1
   VERSION ${PROJECT_VERSION}
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN TRUE
   PUBLIC_HEADER Iir.h
   PRIVATE_HEADER "${LIBINCLUDE}")
 

--- a/iir/Biquad.h
+++ b/iir/Biquad.h
@@ -42,14 +42,14 @@
 
 namespace Iir {
 	
-	struct DllExport BiquadPoleState;
+	struct IIR_EXPORT BiquadPoleState;
 	
 /*
  * Holds coefficients for a second order Infinite Impulse Response
  * digital filter. This is the building block for all IIR filters.
  *
  */
-	class DllExport Biquad {
+	class IIR_EXPORT Biquad {
 	public:
 
 	Biquad() = default;
@@ -172,7 +172,7 @@ namespace Iir {
  * Expresses a biquad as a pair of pole/zeros, with gain
  * values so that the coefficients can be reconstructed precisely.
  **/
-	struct DllExport BiquadPoleState : PoleZeroPair
+	struct IIR_EXPORT BiquadPoleState : PoleZeroPair
 	{
 		BiquadPoleState () = default;
 

--- a/iir/Butterworth.h
+++ b/iir/Butterworth.h
@@ -54,7 +54,7 @@ namespace Butterworth {
 /**
  * Analogue lowpass prototypes (s-plane)
  **/
-class DllExport AnalogLowPass : public LayoutBase
+class IIR_EXPORT AnalogLowPass : public LayoutBase
 {
 public:
 	AnalogLowPass ();
@@ -70,7 +70,7 @@ private:
 /**
  * Analogue low shelf prototypes (s-plane)
  **/
-class DllExport AnalogLowShelf : public LayoutBase
+class IIR_EXPORT AnalogLowShelf : public LayoutBase
 {
 public:
 	AnalogLowShelf ();
@@ -84,47 +84,47 @@ private:
 
 //------------------------------------------------------------------------------
 
-struct DllExport LowPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT LowPassBase : PoleFilterBase <AnalogLowPass>
 {
 	void setup (int order,
 		    double cutoffFrequency);
 };
 
-struct DllExport HighPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT HighPassBase : PoleFilterBase <AnalogLowPass>
 {
 	void setup (int order,
 		    double cutoffFrequency);
 };
 
-struct DllExport BandPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT BandPassBase : PoleFilterBase <AnalogLowPass>
 {
 	void setup (int order,
 		    double centerFrequency,
 		    double widthFrequency);
 };
 
-struct DllExport BandStopBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT BandStopBase : PoleFilterBase <AnalogLowPass>
 {
 	void setup (int order,
 		    double centerFrequency,
 		    double widthFrequency);
 };
 
-struct DllExport LowShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT LowShelfBase : PoleFilterBase <AnalogLowShelf>
 {
 	void setup (int order,
 		    double cutoffFrequency,
 		    double gainDb);
 };
 
-struct DllExport HighShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT HighShelfBase : PoleFilterBase <AnalogLowShelf>
 {
 	void setup (int order,
 		    double cutoffFrequency,
 		    double gainDb);
 };
 
-struct DllExport BandShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT BandShelfBase : PoleFilterBase <AnalogLowShelf>
 {
 	void setup (int order,
 		    double centerFrequency,
@@ -144,7 +144,7 @@ struct DllExport BandShelfBase : PoleFilterBase <AnalogLowShelf>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport LowPass : PoleFilter <LowPassBase, StateType, FilterOrder>
+struct LowPass : PoleFilter <LowPassBase, StateType, FilterOrder>
 {
 	/**
 	 * Calculates the coefficients
@@ -200,7 +200,7 @@ struct DllExport LowPass : PoleFilter <LowPassBase, StateType, FilterOrder>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport HighPass : PoleFilter <HighPassBase, StateType, FilterOrder>
+struct HighPass : PoleFilter <HighPassBase, StateType, FilterOrder>
 {
 
 	/**
@@ -255,7 +255,7 @@ struct DllExport HighPass : PoleFilter <HighPassBase, StateType, FilterOrder>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport BandPass : PoleFilter <BandPassBase, StateType, FilterOrder, FilterOrder*2>
+struct BandPass : PoleFilter <BandPassBase, StateType, FilterOrder, FilterOrder*2>
 {
 	/**
 	 * Calculates the coefficients with the filter order provided by the instantiation
@@ -325,7 +325,7 @@ struct DllExport BandPass : PoleFilter <BandPassBase, StateType, FilterOrder, Fi
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport BandStop : PoleFilter <BandStopBase, StateType, FilterOrder, FilterOrder*2>
+struct BandStop : PoleFilter <BandStopBase, StateType, FilterOrder, FilterOrder*2>
 {
 	/**
 	 * Calculates the coefficients with the filter order provided by the instantiation
@@ -396,7 +396,7 @@ struct DllExport BandStop : PoleFilter <BandStopBase, StateType, FilterOrder, Fi
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport LowShelf : PoleFilter <LowShelfBase, StateType, FilterOrder>
+struct LowShelf : PoleFilter <LowShelfBase, StateType, FilterOrder>
 {
 	/**
 	 * Calculates the coefficients with the filter order provided by the instantiation
@@ -469,7 +469,7 @@ struct DllExport LowShelf : PoleFilter <LowShelfBase, StateType, FilterOrder>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport HighShelf : PoleFilter <HighShelfBase, StateType, FilterOrder>
+struct HighShelf : PoleFilter <HighShelfBase, StateType, FilterOrder>
 {
 	/**
 	 * Calculates the coefficients with the filter order provided by the instantiation
@@ -540,7 +540,7 @@ struct DllExport HighShelf : PoleFilter <HighShelfBase, StateType, FilterOrder>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport BandShelf : PoleFilter <BandShelfBase, StateType, FilterOrder, FilterOrder*2>
+struct BandShelf : PoleFilter <BandShelfBase, StateType, FilterOrder, FilterOrder*2>
 {
 	/**
 	 * Calculates the coefficients with the filter order provided by the instantiation

--- a/iir/Cascade.h
+++ b/iir/Cascade.h
@@ -46,7 +46,7 @@ namespace Iir {
 /**
  * Holds coefficients for a cascade of second order sections.
  **/
-        class DllExport Cascade
+        class IIR_EXPORT Cascade
         {
         public:
         
@@ -56,7 +56,7 @@ namespace Iir {
          * To return the array from a function and to set it.
 	 * Transmits number of stages and the pointer to the array.
          **/
-        struct DllExport Storage
+        struct IIR_EXPORT Storage
         {
                 int maxStages = 0;
                 Biquad* stageArray = nullptr;
@@ -111,7 +111,7 @@ namespace Iir {
  * with its coefficients.
  **/
         template <int MaxStages,class StateType>
-        class DllExport CascadeStages {
+        class CascadeStages {
 
 	public:
 	CascadeStages() = default;

--- a/iir/ChebyshevI.h
+++ b/iir/ChebyshevI.h
@@ -52,7 +52,7 @@ namespace ChebyshevI {
 /**
  * Analog lowpass prototypes (s-plane)
  **/
-class DllExport AnalogLowPass : public LayoutBase
+class IIR_EXPORT AnalogLowPass : public LayoutBase
 {
 public:
 	AnalogLowPass ();
@@ -68,7 +68,7 @@ private:
 /**
  * Analog lowpass shelf prototype (s-plane)
  **/
-class DllExport AnalogLowShelf : public LayoutBase
+class IIR_EXPORT AnalogLowShelf : public LayoutBase
 {
 public:
 	AnalogLowShelf ();
@@ -85,21 +85,21 @@ private:
 
 //------------------------------------------------------------------------------
 
-struct DllExport LowPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT LowPassBase : PoleFilterBase <AnalogLowPass>
 {
   void setup (int order,
               double cutoffFrequency,
               double rippleDb);
 };
 
-struct DllExport HighPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT HighPassBase : PoleFilterBase <AnalogLowPass>
 {
   void setup (int order,
               double cutoffFrequency,
               double rippleDb);
 };
 
-struct DllExport BandPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT BandPassBase : PoleFilterBase <AnalogLowPass>
 {
   void setup (int order,
               double centerFrequency,
@@ -107,7 +107,7 @@ struct DllExport BandPassBase : PoleFilterBase <AnalogLowPass>
               double rippleDb);
 };
 
-struct DllExport BandStopBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT BandStopBase : PoleFilterBase <AnalogLowPass>
 {
   void setup (int order,
               double centerFrequency,
@@ -115,7 +115,7 @@ struct DllExport BandStopBase : PoleFilterBase <AnalogLowPass>
               double rippleDb);
 };
 
-struct DllExport LowShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT LowShelfBase : PoleFilterBase <AnalogLowShelf>
 {
   void setup (int order,
               double cutoffFrequency,
@@ -123,7 +123,7 @@ struct DllExport LowShelfBase : PoleFilterBase <AnalogLowShelf>
               double rippleDb);
 };
 
-struct DllExport HighShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT HighShelfBase : PoleFilterBase <AnalogLowShelf>
 {
   void setup (int order,
               double cutoffFrequency,
@@ -131,7 +131,7 @@ struct DllExport HighShelfBase : PoleFilterBase <AnalogLowShelf>
               double rippleDb);
 };
 
-struct DllExport BandShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT BandShelfBase : PoleFilterBase <AnalogLowShelf>
 {
   void setup (int order,
               double centerFrequency,
@@ -152,7 +152,7 @@ struct DllExport BandShelfBase : PoleFilterBase <AnalogLowShelf>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-	struct DllExport LowPass : PoleFilter <LowPassBase, StateType, FilterOrder>
+	struct LowPass : PoleFilter <LowPassBase, StateType, FilterOrder>
 	{
 		/**
 		 * Calculates the coefficients of the filter at the order FilterOrder
@@ -221,7 +221,7 @@ template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STAT
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-	struct DllExport HighPass : PoleFilter <HighPassBase, StateType, FilterOrder>
+	struct HighPass : PoleFilter <HighPassBase, StateType, FilterOrder>
 	{
 		/**
 		 * Calculates the coefficients of the filter at the order FilterOrder
@@ -290,7 +290,7 @@ template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STAT
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-	struct DllExport BandPass : PoleFilter <BandPassBase, StateType, FilterOrder, FilterOrder*2>
+	struct BandPass : PoleFilter <BandPassBase, StateType, FilterOrder, FilterOrder*2>
 	{
 		/**
 		 * Calculates the coefficients of the filter at the order FilterOrder
@@ -371,7 +371,7 @@ template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STAT
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-	struct DllExport BandStop : PoleFilter <BandStopBase, StateType, FilterOrder, FilterOrder*2>
+	struct BandStop : PoleFilter <BandStopBase, StateType, FilterOrder, FilterOrder*2>
 	{
 		/**
 		 * Calculates the coefficients of the filter at the order FilterOrder
@@ -453,7 +453,7 @@ template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STAT
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-	struct DllExport LowShelf : PoleFilter <LowShelfBase, StateType, FilterOrder>
+	struct LowShelf : PoleFilter <LowShelfBase, StateType, FilterOrder>
 	{
 		/**
 		 * Calculates the coefficients of the filter at the order FilterOrder
@@ -534,7 +534,7 @@ template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STAT
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-	struct DllExport HighShelf : PoleFilter <HighShelfBase, StateType, FilterOrder>
+	struct HighShelf : PoleFilter <HighShelfBase, StateType, FilterOrder>
 	{
 		/**
 		 * Calculates the coefficients of the filter at the order FilterOrder
@@ -617,7 +617,7 @@ template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STAT
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-	struct DllExport BandShelf : PoleFilter <BandShelfBase, StateType, FilterOrder, FilterOrder*2>
+	struct BandShelf : PoleFilter <BandShelfBase, StateType, FilterOrder, FilterOrder*2>
 	{
 		/**
 		 * Calculates the coefficients of the filter at the order FilterOrder

--- a/iir/ChebyshevII.h
+++ b/iir/ChebyshevII.h
@@ -55,7 +55,7 @@ namespace ChebyshevII {
 /**
  * Analogue lowpass prototype (s-plane)
  **/
-class DllExport AnalogLowPass : public LayoutBase
+class IIR_EXPORT AnalogLowPass : public LayoutBase
 {
 public:
 	AnalogLowPass ();
@@ -72,7 +72,7 @@ private:
 /**
  * Analogue shelf lowpass prototype (s-plane)
  **/
-class DllExport AnalogLowShelf : public LayoutBase
+class IIR_EXPORT AnalogLowShelf : public LayoutBase
 {
 public:
 	AnalogLowShelf ();
@@ -89,21 +89,21 @@ private:
 
 //------------------------------------------------------------------------------
 
-struct DllExport LowPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT LowPassBase : PoleFilterBase <AnalogLowPass>
 {
 	void setup (int order,
 		    double cutoffFrequency,
 		    double stopBandDb);
 };
 
-struct DllExport HighPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT HighPassBase : PoleFilterBase <AnalogLowPass>
 {
 	void setup (int order,
 		    double cutoffFrequency,
 		    double stopBandDb);
 };
 
-struct DllExport BandPassBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT BandPassBase : PoleFilterBase <AnalogLowPass>
 {
 	void setup (int order,
 		    double centerFrequency,
@@ -111,7 +111,7 @@ struct DllExport BandPassBase : PoleFilterBase <AnalogLowPass>
 		    double stopBandDb);
 };
 
-struct DllExport BandStopBase : PoleFilterBase <AnalogLowPass>
+struct IIR_EXPORT BandStopBase : PoleFilterBase <AnalogLowPass>
 {
 	void setup (int order,
 		    double centerFrequency,
@@ -119,7 +119,7 @@ struct DllExport BandStopBase : PoleFilterBase <AnalogLowPass>
 		    double stopBandDb);
 };
 
-struct DllExport LowShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT LowShelfBase : PoleFilterBase <AnalogLowShelf>
 {
 	void setup (int order,
 		    double cutoffFrequency,
@@ -127,7 +127,7 @@ struct DllExport LowShelfBase : PoleFilterBase <AnalogLowShelf>
 		    double stopBandDb);
 };
 
-struct DllExport HighShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT HighShelfBase : PoleFilterBase <AnalogLowShelf>
 {
 	void setup (int order,
 		    double cutoffFrequency,
@@ -135,7 +135,7 @@ struct DllExport HighShelfBase : PoleFilterBase <AnalogLowShelf>
 		    double stopBandDb);
 };
 
-struct DllExport BandShelfBase : PoleFilterBase <AnalogLowShelf>
+struct IIR_EXPORT BandShelfBase : PoleFilterBase <AnalogLowShelf>
 {
 	void setup (int order,
 		    double centerFrequency,
@@ -156,7 +156,7 @@ struct DllExport BandShelfBase : PoleFilterBase <AnalogLowShelf>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport LowPass : PoleFilter <LowPassBase, StateType, FilterOrder>
+struct LowPass : PoleFilter <LowPassBase, StateType, FilterOrder>
 {
 	/**
 	 * Calculates the coefficients of the filter
@@ -228,7 +228,7 @@ struct DllExport LowPass : PoleFilter <LowPassBase, StateType, FilterOrder>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport HighPass : PoleFilter <HighPassBase, StateType, FilterOrder>
+struct HighPass : PoleFilter <HighPassBase, StateType, FilterOrder>
 {
 	/**
 	 * Calculates the coefficients of the filter
@@ -299,7 +299,7 @@ struct DllExport HighPass : PoleFilter <HighPassBase, StateType, FilterOrder>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport BandPass : PoleFilter <BandPassBase, StateType, FilterOrder, FilterOrder*2>
+struct BandPass : PoleFilter <BandPassBase, StateType, FilterOrder, FilterOrder*2>
 {
 	/**
 	 * Calculates the coefficients of the filter
@@ -381,7 +381,7 @@ struct DllExport BandPass : PoleFilter <BandPassBase, StateType, FilterOrder, Fi
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  */
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport BandStop : PoleFilter <BandStopBase, StateType, FilterOrder, FilterOrder*2>
+struct BandStop : PoleFilter <BandStopBase, StateType, FilterOrder, FilterOrder*2>
 {
 	/**
 	 * Calculates the coefficients of the filter
@@ -463,7 +463,7 @@ struct DllExport BandStop : PoleFilter <BandStopBase, StateType, FilterOrder, Fi
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport LowShelf : PoleFilter <LowShelfBase, StateType, FilterOrder>
+struct LowShelf : PoleFilter <LowShelfBase, StateType, FilterOrder>
 {
 	/**
 	 * Calculates the coefficients of the filter
@@ -547,7 +547,7 @@ struct DllExport LowShelf : PoleFilter <LowShelfBase, StateType, FilterOrder>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport HighShelf : PoleFilter <HighShelfBase, StateType, FilterOrder>
+struct HighShelf : PoleFilter <HighShelfBase, StateType, FilterOrder>
 {
 	/**
 	 * Calculates the coefficients of the filter
@@ -632,7 +632,7 @@ struct DllExport HighShelf : PoleFilter <HighShelfBase, StateType, FilterOrder>
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int FilterOrder = DEFAULT_FILTER_ORDER, class StateType = DEFAULT_STATE>
-struct DllExport BandShelf : PoleFilter <BandShelfBase, StateType, FilterOrder, FilterOrder*2>
+struct BandShelf : PoleFilter <BandShelfBase, StateType, FilterOrder, FilterOrder*2>
 {
 	/**
 	 * Calculates the coefficients of the filter

--- a/iir/Common.h
+++ b/iir/Common.h
@@ -42,16 +42,19 @@
 
 #ifdef _MSC_VER
 #  pragma warning (disable: 4100)
-#endif
-
-// This exports the classes/structures to the windows DLL
-#ifdef _WIN32
-#  define DllExport   __declspec( dllexport )
 #  ifndef _CRT_SECURE_NO_WARNINGS
 #    define _CRT_SECURE_NO_WARNINGS
 #  endif
+#endif
+
+#ifdef iir_EXPORTS
+#  ifdef _WIN32
+#    define IIR_EXPORT __declspec(dllexport)
+#  else
+#    define IIR_EXPORT __attribute__((visibility("default")))
+#  endif
 #else
-#  define DllExport
+#  define IIR_EXPORT
 #endif
 
 #include <stdlib.h>

--- a/iir/Custom.h
+++ b/iir/Custom.h
@@ -87,7 +87,7 @@ struct TwoPole : public Biquad
  * \param StateType The filter topology: DirectFormI, DirectFormII, ...
  **/
 template <int NSOS, class StateType = DEFAULT_STATE>
-struct DllExport SOSCascade : CascadeStages<NSOS,StateType>
+struct SOSCascade : CascadeStages<NSOS,StateType>
 {
 	/**
 	 * Default constructor which creates a unity gain filter of NSOS biquads.

--- a/iir/Layout.h
+++ b/iir/Layout.h
@@ -59,7 +59,7 @@ namespace Iir {
 /**
  * Base uses pointers to reduce template instantiations
  **/
-	class DllExport LayoutBase
+	class IIR_EXPORT LayoutBase
 	{
 	public:
 		LayoutBase ()
@@ -179,7 +179,7 @@ namespace Iir {
  * Storage for Layout
  **/
 	template <int MaxPoles>
-		class DllExport Layout
+		class Layout
 	{
 	public:
 		operator LayoutBase ()

--- a/iir/MathSupplement.h
+++ b/iir/MathSupplement.h
@@ -42,8 +42,8 @@
 
 #ifdef _MSC_VER
  // Under Unix these have already default instantiations but not under Vis Studio
-template class DllExport std::complex<double>;
-template class DllExport std::complex<float>;
+template class std::complex<double>;
+template class std::complex<float>;
 #endif
 
 namespace Iir {

--- a/iir/PoleFilter.h
+++ b/iir/PoleFilter.h
@@ -59,7 +59,7 @@ namespace Iir {
 /**
  * Factored implementations to reduce template instantiations
  **/
-	class DllExport PoleFilterBase2 : public Cascade
+	class IIR_EXPORT PoleFilterBase2 : public Cascade
 	{
 	public:
 		// This gets the poles/zeros directly from the digital
@@ -91,7 +91,7 @@ namespace Iir {
  * and the digital pole/zero layout.
  **/
 	template <class AnalogPrototype>
-	class DllExport PoleFilterBase : public PoleFilterBase2
+	class PoleFilterBase : public PoleFilterBase2
 	{
 	protected:
 		void setPrototypeStorage (const LayoutBase& analogStorage,
@@ -157,7 +157,7 @@ namespace Iir {
 /** 
  * low pass to low pass 
  **/
-	class DllExport LowPassTransform
+	class IIR_EXPORT LowPassTransform
 	{
 	public:
 	LowPassTransform (double fc,
@@ -175,7 +175,7 @@ namespace Iir {
 /**
  * low pass to high pass
  **/
-	class DllExport HighPassTransform
+	class IIR_EXPORT HighPassTransform
 	{
 	public:
 	HighPassTransform (double fc,
@@ -193,7 +193,7 @@ namespace Iir {
 /**
  * low pass to band pass transform
  **/
-	class DllExport BandPassTransform
+	class IIR_EXPORT BandPassTransform
 	{
 
 	public:
@@ -220,7 +220,7 @@ namespace Iir {
 /** 
  * low pass to band stop transform
  **/
-	class DllExport BandStopTransform
+	class IIR_EXPORT BandStopTransform
 	{
 	public:
 	BandStopTransform (double fc,

--- a/iir/RBJ.h
+++ b/iir/RBJ.h
@@ -63,7 +63,7 @@ namespace RBJ {
 	/** 
          * The base class of all RBJ filters
          **/
-	struct DllExport RBJbase : Biquad
+	struct IIR_EXPORT RBJbase : Biquad
 	{
 	public:
 		/// filter operation
@@ -86,7 +86,7 @@ namespace RBJ {
 	/**
          * Lowpass.
          **/
-	struct DllExport LowPass : RBJbase
+	struct IIR_EXPORT LowPass : RBJbase
 	{
 		/**
                  * Calculates the coefficients
@@ -112,7 +112,7 @@ namespace RBJ {
 	/**
          * Highpass.
          **/
-	struct DllExport HighPass : RBJbase
+	struct IIR_EXPORT HighPass : RBJbase
 	{
 		/**
                  * Calculates the coefficients
@@ -137,7 +137,7 @@ namespace RBJ {
 	/**
          * Bandpass with constant skirt gain
          **/
-	struct DllExport BandPass1 : RBJbase
+	struct IIR_EXPORT BandPass1 : RBJbase
 	{
 		/**
                  * Calculates the coefficients
@@ -162,7 +162,7 @@ namespace RBJ {
 	/**
          * Bandpass with constant 0 dB peak gain
          **/
-	struct DllExport BandPass2 : RBJbase
+	struct IIR_EXPORT BandPass2 : RBJbase
 	{
 		/**
                  * Calculates the coefficients
@@ -188,7 +188,7 @@ namespace RBJ {
          * Bandstop filter. Warning: the bandwidth might not be accurate
          * for narrow notches.
          **/
-	struct DllExport BandStop : RBJbase
+	struct IIR_EXPORT BandStop : RBJbase
 	{
 		/**
                  * Calculates the coefficients
@@ -221,7 +221,7 @@ namespace RBJ {
          * the angles of the poles/zeros define the bandstop frequency. The higher
          * Q the closer r moves towards the unit circle.
          **/
-	struct DllExport IIRNotch : RBJbase
+	struct IIR_EXPORT IIRNotch : RBJbase
 	{
 		/**
                  * Calculates the coefficients
@@ -246,7 +246,7 @@ namespace RBJ {
 	/**
          * Low shelf: 0db in the stopband and gainDb in the passband.
          **/
-	struct DllExport LowShelf : RBJbase
+	struct IIR_EXPORT LowShelf : RBJbase
 	{
 		/**
 		 * Calculates the coefficients
@@ -275,7 +275,7 @@ namespace RBJ {
 	/**
          * High shelf: 0db in the stopband and gainDb in the passband.
          **/
-	struct DllExport HighShelf : RBJbase
+	struct IIR_EXPORT HighShelf : RBJbase
 	{
 		/**
 		 * Calculates the coefficients
@@ -304,7 +304,7 @@ namespace RBJ {
 	/**
          * Band shelf: 0db in the stopband and gainDb in the passband.
          **/
-	struct DllExport BandShelf : RBJbase
+	struct IIR_EXPORT BandShelf : RBJbase
 	{
 		/**
 		 * Calculates the coefficients
@@ -333,7 +333,7 @@ namespace RBJ {
 	/**
 	 * Allpass filter
 	 **/
-	struct DllExport AllPass : RBJbase
+	struct IIR_EXPORT AllPass : RBJbase
 	{
 		/**
 		 * Calculates the coefficients

--- a/iir/State.h
+++ b/iir/State.h
@@ -52,7 +52,7 @@ namespace Iir {
  *  y[n] = (b0/a0)*x[n] + (b1/a0)*x[n-1] + (b2/a0)*x[n-2]
  *                      - (a1/a0)*y[n-1] - (a2/a0)*y[n-2]  
  **/
-	class DllExport DirectFormI
+	class IIR_EXPORT DirectFormI
 	{
 	public:
 	DirectFormI () = default;
@@ -96,7 +96,7 @@ namespace Iir {
  *  y(n) = (b0/a0)*v[n] + (b1/a0)*v[n-1] + (b2/a0)*v[n-2]
  *
  **/
-	class DllExport DirectFormII
+	class IIR_EXPORT DirectFormII
 	{
 	public:
 	DirectFormII () = default;
@@ -127,7 +127,7 @@ namespace Iir {
 
 //------------------------------------------------------------------------------
 	
-	class DllExport TransposedDirectFormII
+	class IIR_EXPORT TransposedDirectFormII
 	{
 	public:
 	TransposedDirectFormII() = default;

--- a/iir/Types.h
+++ b/iir/Types.h
@@ -44,7 +44,7 @@ namespace Iir {
 /**
  * A conjugate or real pair
  **/
-	struct DllExport ComplexPair : complex_pair_t
+	struct IIR_EXPORT ComplexPair : complex_pair_t
 	{
 		ComplexPair() = default;
 
@@ -94,7 +94,7 @@ namespace Iir {
 /**
  * A pair of pole/zeros. This fits in a biquad (but is missing the gain)
  **/
-	struct DllExport PoleZeroPair
+	struct IIR_EXPORT PoleZeroPair
 	{
 		ComplexPair poles = ComplexPair();
 		ComplexPair zeros = ComplexPair();


### PR DESCRIPTION
- rename `DllExport` to `IIR_EXPORT`, since the former is a too generic name
- always define `IIR_EXPORT` to empty in static lib (there was a `__declspec(dllexport)` during build of static lib on Windows, not good).
- hide all private symbols regardless of os/compiler
- do not try to export templates, they can't be exported by definition (except explicit instantiations, but it's tricky and there is no explicit instantiation in iir1)