### PR TITLE
CMake: use cxx_std_11 compile feature instead of CMAKE_CXX_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(iir VERSION 1.9.4 LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
-
-set(CMAKE_CXX_STANDARD 11)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
@@ -64,6 +62,8 @@ target_include_directories(iir
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/iir>  # everything else
 )
 
+target_compile_features(iir PUBLIC cxx_std_11)
+
 set_target_properties(iir PROPERTIES
   SOVERSION 1
   VERSION ${PROJECT_VERSION}
@@ -96,6 +96,8 @@ target_include_directories(iir_static
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/iir>  # everything else
 )
+
+target_compile_features(iir_static PUBLIC cxx_std_11)
 
 set_target_properties(iir_static PROPERTIES
   POSITION_INDEPENDENT_CODE TRUE

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,9 +1,3 @@
-project(IIRDemo)
-
-cmake_minimum_required(VERSION 3.1.0)
-
-set(CMAKE_CXX_STANDARD 11)
-
 if (MSVC)
     add_compile_options(/W4 /WX)
   else()
@@ -12,12 +6,15 @@ endif()
 
 add_executable (iirdemo iirdemo.cpp)
 target_link_libraries(iirdemo iir_static)
+target_compile_features(iirdemo PRIVATE cxx_std_11)
 target_include_directories(iirdemo PRIVATE ..)
 
 add_executable (rbj_update rbj_update.cpp)
 target_link_libraries(rbj_update iir_static)
+target_compile_features(rbj_update PRIVATE cxx_std_11)
 target_include_directories(rbj_update PRIVATE ..)
 
 add_executable (ecg50hzfilt ecg50hzfilt.cpp)
 target_link_libraries(ecg50hzfilt iir_static)
+target_compile_features(ecg50hzfilt PRIVATE cxx_std_11)
 target_include_directories(ecg50hzfilt PRIVATE ..)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.1.0)
-
-set(CMAKE_CXX_STANDARD 11)
-
 if (MSVC)
   add_compile_options(/W4)
 else()
@@ -16,32 +12,40 @@ include_directories(
 
 add_executable (test_butterworth butterworth.cpp)
 target_link_libraries(test_butterworth iir_static)
+target_compile_features(test_butterworth PRIVATE cxx_std_11)
 add_test(TestButterworth test_butterworth)
 
 add_executable (test_chebyshev1 chebyshev1.cpp)
 target_link_libraries(test_chebyshev1 iir_static)
+target_compile_features(test_chebyshev1 PRIVATE cxx_std_11)
 add_test(TestChebyshev1 test_chebyshev1)
 
 add_executable (test_chebyshev2 chebyshev2.cpp)
 target_link_libraries(test_chebyshev2 iir_static)
+target_compile_features(test_chebyshev2 PRIVATE cxx_std_11)
 add_test(TestChebyshev2 test_chebyshev2)
 
 add_executable (test_rbj rbj.cpp)
 target_link_libraries(test_rbj iir_static)
+target_compile_features(test_rbj PRIVATE cxx_std_11)
 add_test(TestRBJ test_rbj)
 
 add_executable (test_custom custom.cpp)
 target_link_libraries(test_custom iir_static)
+target_compile_features(test_custom PRIVATE cxx_std_11)
 add_test(TestCUSTOM test_custom)
 
 add_executable (test_badparam badparam.cpp)
 target_link_libraries(test_badparam iir_static)
+target_compile_features(test_badparam PRIVATE cxx_std_11)
 add_test(TestBadParam test_badparam)
 
 add_executable (test_state state.cpp)
 target_link_libraries(test_state iir_static)
+target_compile_features(test_state PRIVATE cxx_std_11)
 add_test(TestState test_state)
 
 add_executable (test_assignment assignment.cpp)
 target_link_libraries(test_assignment iir_static)
+target_compile_features(test_state PRIVATE cxx_std_11)
 add_test(TestOperator= test_assignment)


### PR DESCRIPTION
- cxx_std_11 allows to override C++ standard externally while CMAKE_CXX_STANDARD hardcodes it internally, preventing any change for consumers to set another standard like C++14, 17, 20 etc (usually users like to use the same C++ standard in the all dependency graph).
- cxx_std_11 is propagated to features of import target in CMake config file