### PR TITLE
CMake: remove useless enforcements of CMake policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif()
 
-cmake_policy(SET CMP0048 NEW) # set VERSION in project()
-cmake_policy(SET CMP0042 NEW) # enable MACOSX_RPATH by default
-
 option(INSTALL_STATIC "Build static library" ON)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
CMP0048 & CMP0042 are already NEW as per current cmake_minimum_required to 3.1