### PR TITLE
CMake: remove useless include_directories in demo & test

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -12,12 +12,9 @@ endif()
 
 add_executable (iirdemo iirdemo.cpp)
 target_link_libraries(iirdemo iir_static)
-target_include_directories(iirdemo PRIVATE ..)
 
 add_executable (rbj_update rbj_update.cpp)
 target_link_libraries(rbj_update iir_static)
-target_include_directories(rbj_update PRIVATE ..)
 
 add_executable (ecg50hzfilt ecg50hzfilt.cpp)
 target_link_libraries(ecg50hzfilt iir_static)
-target_include_directories(ecg50hzfilt PRIVATE ..)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,10 +9,6 @@ else()
 endif()
 
 enable_testing()
-include_directories(
-  ..
-  ../iir
-  )
 
 add_executable (test_butterworth butterworth.cpp)
 target_link_libraries(test_butterworth iir_static)


### PR DESCRIPTION
include dirs of irr lib are already propagated through target_link_libraries to iir_static