### PR TITLE
CMake: add `IIR1_DEV_FLAGS` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,20 +14,24 @@ cmake_policy(SET CMP0048 NEW) # set VERSION in project()
 cmake_policy(SET CMP0042 NEW) # enable MACOSX_RPATH by default
 
 option(INSTALL_STATIC "Build static library" ON)
+option(IIR1_DEV_FLAGS "Enable developer flags" ON)
 
 include(GNUInstallDirs)
+
+if(IIR1_DEV_FLAGS)
+  if (MSVC)
+    add_compile_options(/W4 /WX)
+  else()
+    add_compile_options(-Wall -Wconversion -Wextra -pedantic -Werror)
+  endif()
+endif()
+
 # If including this project in another project, use IIR1_BUILD_TESTING to enable local testing
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR IIR1_BUILD_TESTING)
     add_subdirectory(test)
     enable_testing ()
 endif()
 add_subdirectory(demo)
-
-if (MSVC)
-  add_compile_options(/W4)
-else()
-  add_compile_options(-Wall -Wconversion -Wextra -pedantic)
-endif()
 
 set(LIBSRC
   iir/Biquad.cpp

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -4,12 +4,6 @@ cmake_minimum_required(VERSION 3.1.0)
 
 set(CMAKE_CXX_STANDARD 11)
 
-if (MSVC)
-    add_compile_options(/W4 /WX)
-  else()
-    add_compile_options(-Wall -Wextra -pedantic -Werror)
-endif()
-
 add_executable (iirdemo iirdemo.cpp)
 target_link_libraries(iirdemo iir_static)
 target_include_directories(iirdemo PRIVATE ..)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,12 +2,6 @@ cmake_minimum_required(VERSION 3.1.0)
 
 set(CMAKE_CXX_STANDARD 11)
 
-if (MSVC)
-  add_compile_options(/W4)
-else()
-  add_compile_options(-Wall -Wconversion -Wextra -pedantic)
-endif()
-
 enable_testing()
 include_directories(
   ..


### PR DESCRIPTION
allows to disable these flags which may break build with more recent compilers due to new warnings