### PR TITLE
windows: Avoid to put `__declspec(dllexport)` at consume time of shared lib or at build/consume time of static lib

### DIFF
--- a/iir/Common.h
+++ b/iir/Common.h
@@ -42,14 +42,14 @@
 
 #ifdef _MSC_VER
 #  pragma warning (disable: 4100)
-#endif
-
-// This exports the classes/structures to the windows DLL
-#ifdef _WIN32
-#  define IIR_EXPORT __declspec( dllexport )
 #  ifndef _CRT_SECURE_NO_WARNINGS
 #    define _CRT_SECURE_NO_WARNINGS
 #  endif
+#endif
+
+// This exports the classes/structures to the windows DLL
+#if defined(_WIN32) && defined(iir_EXPORTS)
+#  define IIR_EXPORT __declspec( dllexport )
 #else
 #  define IIR_EXPORT
 #endif


### PR DESCRIPTION
https://github.com/berndporr/iir1/pull/47 has been partially merged. The part hiding all symbols by default in non-msvc builds have been rejected https://github.com/berndporr/iir1/commit/861efd2e6952f9d25288da44dae08c9f64fa3161. That's ok, but by doing this you have removed another unrelated fix for Windows, which was actually the first fix I had in mind in this PR:

- `__declspec(dllexport)` should not be defined at consume time of shared lib (it's nothing or `__declspec(dllimport)` eventually)
- for static lib, there should not be any `__declspec(dllexport)` at build or consume time

(`<targetName>_EXPORTS` is automatically injected as a private definition by CMake when a target is shared)