### PR TITLE
Do not hardcode PIC in static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,6 @@ target_include_directories(iir_static
 )
 
 set_target_properties(iir_static PROPERTIES
-  POSITION_INDEPENDENT_CODE TRUE
   VERSION ${PROJECT_VERSION}
   PUBLIC_HEADER Iir.h
   PRIVATE_HEADER "${LIBINCLUDE}")


### PR DESCRIPTION
PIC in static lib is a user decision, not irr1 usage requirement. If a user wants static PIC (to link iir1 in a shared lib for example), he can inject CMAKE_POSITION_INDEPENDENT_CODE externally during CMake configuration.